### PR TITLE
feature/5-test-libro: Implementar tests básicos para Libro

### DIFF
--- a/biblioteca-testing/src/test/java/com/juanalejop/biblioteca/model/LibroTest.java
+++ b/biblioteca-testing/src/test/java/com/juanalejop/biblioteca/model/LibroTest.java
@@ -1,0 +1,36 @@
+package com.juanalejop.biblioteca.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import com.juanalejop.biblioteca.util.Estado;
+
+public class LibroTest {
+    private Libro libro;
+
+    @BeforeEach
+    void setUp() {
+        libro = new Libro("978-3-16-148410-0", "Clean Code", "Robert C. Martin");
+    }
+
+    @Test
+    void testCrearLibroValido() {
+        assertEquals("978-3-16-148410-0", libro.getIsbn());
+        assertEquals("Clean Code", libro.getTitulo());
+        assertEquals("Robert C. Martin", libro.getAutor());
+        assertEquals(Estado.DISPONIBLE, libro.getEstado());
+    }
+
+    @Test
+    void testCambiarEstadoPrestado() {
+        libro.cambiarEstado(Estado.PRESTADO);
+        assertEquals(Estado.PRESTADO, libro.getEstado());
+    }
+
+    @Test
+    void testCambiarEstadoDisponible() {
+        libro.cambiarEstado(Estado.PRESTADO);
+        libro.cambiarEstado(Estado.DISPONIBLE);
+        assertEquals(Estado.DISPONIBLE, libro.getEstado());
+    }
+}


### PR DESCRIPTION
## 📌 Descripción
Se agregan pruebas unitarias para la clase `Libro`, verificando la creación correcta del objeto y la transición de estados entre `DISPONIBLE` y `PRESTADO`.

## 🛠 Cambios realizados
- Creada la clase de test `src/test/java/com/juanalejop/biblioteca/model/LibroTest.java`.  
- Añadido método `@BeforeEach setUp()` para inicializar un objeto `Libro` con estado inicial `DISPONIBLE`.  
- Implementados tres tests JUnit5:  
  - `testCrearLibroValido()`  
  - `testCambiarEstadoPrestado()`  
  - `testCambiarEstadoDisponible()` (con paso intermedio a `PRESTADO`)  
- Ajustados imports en el test para eliminar redundancias y traer solo `@Test`, `@BeforeEach`, las aserciones y `Estado`. Porque tanto `Libro` como `LibroTest` están reconocidos dentro del mismo paquete `model`.

## ✅ Checklist
- [x] El código compila correctamente.  
- [x] Se respetan los principios SOLID y POO.  
- [x] El código fue ejecutado y verificado en consola sin errores (si aplica).  
- [ ] La documentación  se actualizó en caso de cambios relevantes (si aplica).

## 🧩 Issue relacionado
Closes #5