### PR TITLE
feature/8-clase-prestamo: implementar clase prestamo

### DIFF
--- a/biblioteca-testing/src/main/java/com/juanalejop/biblioteca/model/Prestamo.java
+++ b/biblioteca-testing/src/main/java/com/juanalejop/biblioteca/model/Prestamo.java
@@ -1,0 +1,26 @@
+package com.juanalejop.biblioteca.model;
+
+import java.time.LocalDate;
+import com.juanalejop.biblioteca.util.Estado;
+
+public class Prestamo {
+    private final  Libro libro;
+    private final LocalDate fechaPrestamo;
+
+    public Prestamo(Libro libro) {
+        if (libro == null) {
+            throw new IllegalArgumentException("El libro no puede ser null");
+        }
+        this.libro = libro;
+        this.fechaPrestamo = LocalDate.now();
+        libro.cambiarEstado(Estado.PRESTADO);
+    }
+
+    public Libro getLibro() {
+        return libro;
+    }
+
+    public LocalDate getFechaPrestamo() {
+        return fechaPrestamo;
+    }
+}


### PR DESCRIPTION
## 📌 Descripción
Se implementa la clase `Prestamo` para modelar el préstamo de un libro, registrando la fecha de préstamo y cambiando automáticamente el estado del libro a `PRESTADO`.

## 🛠 Cambios realizados
- Añadido `src/main/java/com/juanalejop/biblioteca/model/Prestamo.java` con:
  - Atributos `libro` y `fechaPrestamo` marcados como `final`.
  - Constructor que recibe un `Libro`, valida que no sea `null`, asigna `fechaPrestamo = LocalDate.now()` y cambia el estado del libro a `PRESTADO`.
  - Getters `getLibro()` y `getFechaPrestamo()`.
- Inclusión de validación para evitar préstamos con libro `null`.

## ✅ Checklist
- [x] El código compila correctamente.  
- [x] Se respetan los principios SOLID y POO.  
- [ ] El código fue ejecutado y verificado en consola sin errores (si aplica).  
- [ ] La documentación se actualizó en caso de cambios relevantes (si aplica).

## 🧩 Issue relacionado
Closes #8 