### PR TITLE
feature/10-mockito-sistemaprestamos: implementar tests con mockito para sistemaprestamos y corregir dependencias del pom

### DIFF
--- a/biblioteca-testing/pom.xml
+++ b/biblioteca-testing/pom.xml
@@ -31,6 +31,13 @@
       <version>5.3.1</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>5.11.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/biblioteca-testing/src/test/java/com/juanalejop/biblioteca/service/SistemaPrestamosTest.java
+++ b/biblioteca-testing/src/test/java/com/juanalejop/biblioteca/service/SistemaPrestamosTest.java
@@ -1,0 +1,70 @@
+package com.juanalejop.biblioteca.service;
+
+import com.juanalejop.biblioteca.model.Catalogo;
+import com.juanalejop.biblioteca.model.Libro;
+import com.juanalejop.biblioteca.model.Prestamo;
+import com.juanalejop.biblioteca.util.Estado;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class SistemaPrestamosTest {
+    @Mock
+    private Catalogo catalogo;
+
+    @InjectMocks
+    private SistemaPrestamos sistemaPrestamos;
+
+    @Test
+    void testPrestarLibro_Exitoso() {
+        Libro libro = new Libro ("979-8888771389", "The Fragrant Flower Blooms with Dignity (1)", "Saka Mikami");
+        when(catalogo.buscarPorIsbn("979-8888771389"))
+                .thenReturn(Optional.of(libro));
+        Prestamo prestamo = sistemaPrestamos.prestarLibro("979-8888771389");
+    assertNotNull(prestamo, "El Prestamo proporcionado es null");
+    assertEquals(Estado.PRESTADO, libro.getEstado(), "El estado del libro no pasó a PRESTADO");
+    verify(catalogo, times(1)).buscarPorIsbn("979-8888771389");
+    }
+
+    @Test
+    void testPrestarLibro_NoExiste() {
+        when(catalogo.buscarPorIsbn("0000-0-00-000000-0"))
+                .thenReturn(Optional.empty());
+        assertThrows(NoSuchElementException.class, () ->
+                sistemaPrestamos.prestarLibro("0000-0-00-000000-0"),
+                "Debería lanzar NoSuchElementException si el libro no existe");
+        verify(catalogo).buscarPorIsbn("0000-0-00-000000-0");
+    }
+
+    @Test
+    void testDevolverLibro_Exitoso() {
+        Libro libro = new Libro ("979-8888771389", "The Fragrant Flower Blooms with Dignity (1)", "Saka Mikami");
+        libro.cambiarEstado(Estado.PRESTADO);
+        when(catalogo.buscarPorIsbn("979-8888771389"))
+                .thenReturn(Optional.of(libro));
+        sistemaPrestamos.devolverLibro("979-8888771389");
+        assertEquals(Estado.DISPONIBLE, libro.getEstado(), "El estado del libro no pasó a DISPONIBLE");
+        verify(catalogo).buscarPorIsbn("979-8888771389");
+    }
+
+    @Test
+    void testDevolverLibro_NoPrestado() {
+        Libro libro = new Libro ("979-8888771389", "The Fragrant Flower Blooms with Dignity (1)", "Saka Mikami");
+        when(catalogo.buscarPorIsbn("979-8888771389"))
+                .thenReturn(Optional.of(libro));
+        assertThrows(IllegalStateException.class, () ->
+            sistemaPrestamos.devolverLibro("979-8888771389"),
+                "Debería lanzar IllegalStateException si el libro no está PRESTADO");
+        verify(catalogo).buscarPorIsbn("979-8888771389");
+    }
+}


### PR DESCRIPTION
## 📌 Descripción
Se agregan pruebas unitarias para la clase `SistemaPrestamos`, utilizando Mockito para simular el comportamiento del `Catalogo` y verificar los flujos de préstamo y devolución de libros.

## 🛠 Cambios realizados
- Creada la clase de test `src/test/java/com/juanalejop/biblioteca/service/SistemaPrestamosTest.java`.
- Simulado `Catalogo` con `@Mock` y utilizado `@InjectMocks` para inyectar en `SistemaPrestamos`.
- Implementados cuatro tests JUnit5:
  - `testPrestarLibro_Exitoso()` verifica que se crea un préstamo exitoso, que el estado cambia a `PRESTADO`, y que se invoca `catalogo.buscarPorIsbn`.
  - `testPrestarLibro_NoExiste()` verifica que se lanza una `NoSuchElementException` cuando el libro no se encuentra.
  - `testDevolverLibro_Exitoso()` simula un libro previamente prestado y verifica que su estado vuelve a `DISPONIBLE`.
  - `testDevolverLibro_NoPrestado()` comprueba que se lanza una `IllegalStateException` si se intenta devolver un libro que no fue prestado.
- Se verifican interacciones con el mock `catalogo` usando `verify(...)`.
- Se arregló un problema con las dependencias de mockito-junit-jupiter en el `pom.xml`.

## ✅ Checklist
- [x] El código compila correctamente.
- [x] Se respetan los principios SOLID y POO.
- [x] El código fue ejecutado y verificado en consola sin errores (si aplica).
- [ ] La documentación se actualizó en caso de cambios relevantes (si aplica).

## 🧩 Issue relacionado
Closes #10